### PR TITLE
more 0.18

### DIFF
--- a/src/Debouncer.elm
+++ b/src/Debouncer.elm
@@ -8,8 +8,33 @@ manager, it presents a much more minimal and user friendly API.
 
 -}
 
+{-
+   MIT License
+
+   Copyright (c) 2016 Matthew Conger-Eldeen
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+-}
+
 import Task exposing (Task)
 import Dict exposing (Dict)
+import Tuple
 import Process
 
 
@@ -35,20 +60,21 @@ type Msg
 
 
 {-| Debounce takes a key for identification (which allows you to debounce
-multiple things at once), a duration (in milliseconds), and two mapping
-functions that turn your task into a `msg`. The idea is that when the key and
-duration are applied in, it should mirror the Task.perform type signature.
+multiple things at once), a duration (in milliseconds), and a mapping
+functions that turn the `Result` from running your task into a `msg`. The idea
+is that when the key and duration are applied in, it should mirror the
+`Task.attempt` type signature.
 
-    perform : (a -> msg) -> (b -> msg) -> Task a b -> Cmd msg
-    perform =
+    debouncedAttempt : (Result x a -> msg) -> Task x a -> Cmd msg
+    debouncedAttempt =
       debounce "query" 500
 
 -}
-debounce : String -> Float -> (a -> msg) -> (b -> msg) -> Task a b -> Cmd msg
-debounce key delay onFail onSuccess task =
+debounce : String -> Float -> (Result x a -> msg) -> Task x a -> Cmd msg
+debounce key delay msg task =
     task
-        |> Task.map onSuccess
-        |> Task.mapError onFail
+        |> Task.andThen (Task.succeed << msg << Ok)
+        |> Task.onError (Task.succeed << msg << Err)
         |> (command << Debounce key delay)
 
 
@@ -59,7 +85,7 @@ init =
 
 (&>) : Task a b -> Task a c -> Task a c
 (&>) t1 t2 =
-    Task.andThen t1 (\_ -> t2)
+    Task.andThen (\_ -> t2) t1
 
 
 onEffects :
@@ -77,12 +103,13 @@ onEffects router cmds state =
                 updateState v =
                     Dict.insert key v state
             in
-                maybeKill (Maybe.map snd <| Dict.get key state)
+                maybeKill (Maybe.map Tuple.second <| Dict.get key state)
                     &> Process.spawn (eventuallyExecute router key delay)
-                    `Task.andThen` (onEffects router rest
-                                        << updateState
-                                        << (,) task
-                                   )
+                    |> Task.andThen
+                        (onEffects router rest
+                            << updateState
+                            << (,) task
+                        )
 
 
 maybeKill : Maybe Process.Id -> Task x ()
@@ -101,7 +128,7 @@ onSelfMsg : Platform.Router msg Msg -> Msg -> State msg -> Task Never (State msg
 onSelfMsg router selfMsg state =
     case selfMsg of
         Execute key ->
-            Process.spawn (maybeExecuteTask router (Maybe.map fst <| Dict.get key state))
+            Process.spawn (maybeExecuteTask router (Maybe.map Tuple.first <| Dict.get key state))
                 &> Task.succeed (Dict.remove key state)
 
 
@@ -110,8 +137,8 @@ maybeExecuteTask router mTask =
     case mTask of
         Just task ->
             task
-                `Task.andThen` Platform.sendToApp router
-                `Task.onError` Platform.sendToApp router
+                |> Task.andThen (Platform.sendToApp router)
+                |> Task.onError (Platform.sendToApp router)
 
         Nothing ->
             Task.succeed ()


### PR DESCRIPTION
Update to work on 0.18 and change `debounce` signature to look more like 0.18's `Task.attempt`.

* I didn't look to close, so make sure this all works
* also, I didn't change the example or read me or anything else, only the one file